### PR TITLE
#4: flesh out guides structure more, add future guides readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# intellij
+.idea

--- a/guides/README.md
+++ b/guides/README.md
@@ -2,38 +2,43 @@
 
 ## React Code Architecture
 
-| Topic                  | Guides                            | Tools | Rules              | Examples |
-| ---------------------- | --------------------------------- | ----- | ------------------ | -------- |
-| [Hooks](./react/hooks) | How to write hooks [#3](/atlassian/tangerine/issues/3)             | ...   | eslint-react-hooks | ...      |
-| State Management       | Types of State, Remote State, ... | Adone | ...                | ...      |
-
-## Package Structure
-
-| Topic                   | Guides | Tools | Rules | Examples |
-| ----------------------- | ------ | ----- | ----- | -------- |
-| UI Components           | Guide  | ...   | ...   | ...      |
-| Encapsulated Components | Guide  | ...   | ...   | ...      |
-
-### General Tools:
-
-- Stricter
-
-## SPA
-
-See [#2](/atlassian/tangerine/issues/2)
-
-## Documentation
-
-// TODO
-
-## Performance
-
-// TODO
+| Theme                                        | Topic                                                                                               | Guides | Tools | Rules | Examples |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------ | :---: | :---: | :------: |
+| [App structure](./react/app-structure)       | [General info](./react/app-structure)                                                               | ..     |  ..   |  ...  |   ...    |
+|                                              | [UI layer](./react/app-structure/ui-layer)                                                          | ..     |  ..   |  ...  |   ...    |
+|                                              | [Services layer](./react/app-structure/services-layer)                                              | ..     |  ..   |  ...  |   ...    |
+|                                              | [Controllers layer](./react/app-structure/controllers-layer)                                        | ..     |  ..   |  ...  |   ...    |
+|                                              | [Common layer](./react/app-structure/common-layer)                                                  | ..     |  ..   |  ...  |   ...    |
+| [Code structure](./react/code-structure)     | [General info](./react/code-structure)                                                              | ..     |  ..   |  ...  |   ...    |
+|                                              | [UI layer](./react/code-structure/ui-layer)                                                         | ..     |  ..   |  ...  |   ...    |
+|                                              | [UI layer: examples](./react/code-structure/ui-layer/examples.md)                                   | ..     |  ..   |  ...  |   ...    |
+|                                              | [Services layer](./react/code-structure/services-layer)                                             | ..     |  ..   |  ...  |   ...    |
+|                                              | [Controllers layer](./react/code-structure/controllers-layer)                                       | ..     |  ..   |  ...  |   ...    |
+|                                              | [Core patterns](./react/code-structure/core-patterns)                                               | ..     |  ..   |  ...  |   ...    |
+|                                              | [Core patterns: components](./react/code-structure/core-patterns/components.md)                     | ..     |  ..   |  ...  |   ...    |
+|                                              | [Core patterns: dependency injection](./react/code-structure/core-patterns/dependency-injection.md) | ..     |  ..   |  ...  |   ...    |
+| [Hooks](./react/hooks)                       | See [#3](/atlassian/tangerine/issues/3)                                                             | ...    |  ...  |  ...  |   ...    |
+| [State management](./react/state-management) | The state manifesto                                                                                 | ...    |  ...  |  ...  |   ...    |
+| [GraphQL](./react/graphql)                   | ...                                                                                                 | ...    |  ...  |  ...  |   ...    |
+| [SPA](./react/spa)                           | See [#2](/atlassian/tangerine/issues/2)                                                             | ...    |  ...  |  ...  |   ...    |
+| [Performance](./react/performance)           | ...                                                                                                 | ...    |  ...  |  ...  |   ...    |
 
 ## Monorepo Management
 
-// TODO
+| Theme                                              | Topic                                         | Guides | Tools | Rules | Examples |
+| -------------------------------------------------- | --------------------------------------------- | ------ | :---: | :---: | :------: |
+| [Package structure](./monorepo/packages-structure) | [General info](./monorepo/packages-structure) | ..     |  ..   |  ...  |   ...    |
 
 ## Design System
+
+| Theme                            | Topic | Guides | Tools | Rules | Examples |
+| -------------------------------- | ----- | ------ | :---: | :---: | :------: |
+| [Design system](./design-system) | ...   | ..     |  ..   |  ...  |   ...    |
+
+### General Tools:
+
+-   Stricter
+
+## Documentation
 
 // TODO

--- a/guides/design-system/README.md
+++ b/guides/design-system/README.md
@@ -1,0 +1,3 @@
+# Design system
+
+// TODO

--- a/guides/monorepo/README.md
+++ b/guides/monorepo/README.md
@@ -1,0 +1,1 @@
+# All about monorepo and packages

--- a/guides/monorepo/packages-structure/README.md
+++ b/guides/monorepo/packages-structure/README.md
@@ -1,0 +1,1 @@
+# How to structure your packages GUIDE

--- a/guides/react/app-structure/README.md
+++ b/guides/react/app-structure/README.md
@@ -1,0 +1,3 @@
+# How to structure your applications Guide
+
+// TODO

--- a/guides/react/app-structure/common-layer/README.md
+++ b/guides/react/app-structure/common-layer/README.md
@@ -1,0 +1,4 @@
+# All about how to organise your common layer
+
+// files, directories, naming conventions, etc
+// TODO

--- a/guides/react/app-structure/controllers-layer/README.md
+++ b/guides/react/app-structure/controllers-layer/README.md
@@ -1,0 +1,4 @@
+# All about how to organise your controllers layer
+
+// files, directories, naming conventions, etc
+// TODO

--- a/guides/react/app-structure/services-layer/README.md
+++ b/guides/react/app-structure/services-layer/README.md
@@ -1,0 +1,4 @@
+# All about how to organise your services layer
+
+// files, directories, naming conventions, etc
+// TODO

--- a/guides/react/app-structure/ui-layer/README.md
+++ b/guides/react/app-structure/ui-layer/README.md
@@ -1,0 +1,4 @@
+# All about how to organise your ui layer
+
+// files, directories, naming conventions, etc
+// TODO

--- a/guides/react/code-structure/README.md
+++ b/guides/react/code-structure/README.md
@@ -1,0 +1,3 @@
+# General code structure guide
+
+// TODO

--- a/guides/react/code-structure/controllers-layer/README.md
+++ b/guides/react/code-structure/controllers-layer/README.md
@@ -1,0 +1,3 @@
+# What is a controller and how to implement it
+
+// TODO

--- a/guides/react/code-structure/core-patterns/README.md
+++ b/guides/react/code-structure/core-patterns/README.md
@@ -1,0 +1,3 @@
+# Brief intro into why this folder exist
+
+// TODO

--- a/guides/react/code-structure/core-patterns/components.md
+++ b/guides/react/code-structure/core-patterns/components.md
@@ -1,0 +1,3 @@
+# Everything is a component!
+
+// TODO

--- a/guides/react/code-structure/core-patterns/dependency-injection.md
+++ b/guides/react/code-structure/core-patterns/dependency-injection.md
@@ -1,0 +1,3 @@
+# What is dependency injection, why do we use it and how
+
+// TODO

--- a/guides/react/code-structure/services-layer/README.md
+++ b/guides/react/code-structure/services-layer/README.md
@@ -1,0 +1,3 @@
+# What is a service and how to implement it
+
+// TODO

--- a/guides/react/code-structure/ui-layer/README.md
+++ b/guides/react/code-structure/ui-layer/README.md
@@ -1,0 +1,3 @@
+# What is a ui layer and how to implement it
+
+// TODO

--- a/guides/react/code-structure/ui-layer/examples.md
+++ b/guides/react/code-structure/ui-layer/examples.md
@@ -1,0 +1,3 @@
+# What is an example for the UI layer and why do we need it
+
+// TODO

--- a/guides/react/graphql/README.md
+++ b/guides/react/graphql/README.md
@@ -1,0 +1,3 @@
+# All about GraphQL
+
+// TODO

--- a/guides/react/performance/README.md
+++ b/guides/react/performance/README.md
@@ -1,0 +1,3 @@
+# all about performance in React
+
+// TODO

--- a/guides/react/spa/README.md
+++ b/guides/react/spa/README.md
@@ -1,0 +1,3 @@
+# all about SPA
+
+// TODO

--- a/guides/react/state-management/README.md
+++ b/guides/react/state-management/README.md
@@ -1,0 +1,3 @@
+# How to think about your state (the manifesto)
+
+// TODO


### PR DESCRIPTION
Added future guides and a bit more structure.

All guides that are with links are part of tangerine-next and already exist, just need to move them.
Stuff that don't exist yet marked as `...` for now, to reduce the scope of the PR.